### PR TITLE
Let main dimmer control white levels

### DIFF
--- a/devicetypes/erocm123/smartlife-rgbw-controller.src/smartlife-rgbw-controller.groovy
+++ b/devicetypes/erocm123/smartlife-rgbw-controller.src/smartlife-rgbw-controller.groovy
@@ -447,11 +447,11 @@ def setColor(value) {
     else if (value.aLevel) {
     	def actions = []
         
-    	// handle white channels on dim, but only if they were on in the first place
-        if (device.currentValue("white1") == "on")
-        	actions.push(setWhite1Level(value.aLevel))
-        if (device.currentValue("white2") == "on")
-        	actions.push(setWhite2Level(value.aLevel))
+    	// Handle white channel dimmer. Unfortunately, if we first check for white1/2 == "on",
+        // we can't use the dimmer to turn the lights on at a specific level. However, this is already
+        // true for RGB - you can't set a dim level since the "current" rgb values are zeros when off.
+        actions.push(setWhite1Level(value.aLevel))
+        actions.push(setWhite2Level(value.aLevel))
             
         uri = "/rgb?value=${getDimmedColor(device.currentValue("color")).substring(1)}"
         actions.push(postAction("$uri&channels=$channels&transition=$transition"))

--- a/devicetypes/erocm123/smartlife-rgbw-controller.src/smartlife-rgbw-controller.groovy
+++ b/devicetypes/erocm123/smartlife-rgbw-controller.src/smartlife-rgbw-controller.groovy
@@ -445,7 +445,17 @@ def setColor(value) {
        uri = "/w1?value=${value.white}"
     }
     else if (value.aLevel) {
-       uri = "/rgb?value=${getDimmedColor(device.currentValue("color")).substring(1)}"
+    	def actions = []
+        
+    	// handle white channels on dim, but only if they were on in the first place
+        if (device.currentValue("white1") == "on")
+        	actions.push(setWhite1Level(value.aLevel))
+        if (device.currentValue("white2") == "on")
+        	actions.push(setWhite2Level(value.aLevel))
+            
+        uri = "/rgb?value=${getDimmedColor(device.currentValue("color")).substring(1)}"
+        actions.push(postAction("$uri&channels=$channels&transition=$transition"))
+        return actions
     }
     else {
        // A valid color was not chosen. Setting to white

--- a/devicetypes/erocm123/smartlife-rgbw-controller.src/smartlife-rgbw-controller.groovy
+++ b/devicetypes/erocm123/smartlife-rgbw-controller.src/smartlife-rgbw-controller.groovy
@@ -267,6 +267,10 @@ def parse(description) {
     }
     if (result.containsKey("rgb")) {
        events << createEvent(name:"color", value:"#$result.rgb")
+
+       // only store the previous value if the response did not come from a power-off command
+       if (result.power != "off")
+         state.previousRGB = result.rgb
     }
     if (result.containsKey("r")) {
        events << createEvent(name:"redLevel", value: Integer.parseInt(result.r,16)/255 * 100 as Integer, displayed: false)
@@ -299,6 +303,10 @@ def parse(description) {
        } else {
     	  events << createEvent(name:"white1", value: "off", displayed: false)
        }
+
+       // only store the previous value if the response did not come from a power-off command
+       if (result.power != "off")
+          state.previousW1 = result.w1
     }
     if (result.containsKey("w2")) {
        events << createEvent(name:"white2Level", value: Integer.parseInt(result.w2,16)/255 * 100 as Integer, displayed: false)
@@ -307,6 +315,10 @@ def parse(description) {
        } else {
     	  events << createEvent(name:"white2", value: "off", displayed: false)
        }
+
+       // only store the previous value if the response did not come from a power-off command
+       if (result.power != "off")
+          state.previousW2 = result.w2
     }
     if (result.containsKey("version")) {
        events << createEvent(name:"firmware", value: result.version + "\r\n" + result.date, displayed: false)
@@ -447,13 +459,15 @@ def setColor(value) {
     else if (value.aLevel) {
     	def actions = []
         
-    	// Handle white channel dimmer. Unfortunately, if we first check for white1/2 == "on",
-        // we can't use the dimmer to turn the lights on at a specific level. However, this is already
-        // true for RGB - you can't set a dim level since the "current" rgb values are zeros when off.
-        actions.push(setWhite1Level(value.aLevel))
-        actions.push(setWhite2Level(value.aLevel))
-            
-        uri = "/rgb?value=${getDimmedColor(device.currentValue("color")).substring(1)}"
+        // Handle white channel dimmers if they're on or were not previously off (excluding power-off command)
+        if (device.currentValue("white1") == "on" || state.previousW1 != "00")
+          actions.push(setWhite1Level(value.aLevel))
+        if (device.currentValue("white2") == "on" || state.previousW2 != "00")
+          actions.push(setWhite2Level(value.aLevel))
+        
+        // if the device is currently on, scale the current RGB values; otherwise scale the previous setting
+        uri = "/rgb?value=${getDimmedColor(device.latestValue("switch") == "on" ? device.currentValue("color") : state.previousRGB).substring(1)}"
+
         actions.push(postAction("$uri&channels=$channels&transition=$transition"))
         return actions
     }


### PR DESCRIPTION
Currently the main dimmer doesn't control w1 or w2. This fixes that. It also adds a new feature of sorts: use the dimmer directly to turn on the channels.

Previously, if the device was off, sliding the main dimmer did _not_ turn on individual channels since `device.currentValue("color")` would be `"000000"`, and did not activate w1 & w2.

This PR tracks the previous state of rgb, w1, and w2 on every response that is not a power-off command (since the values would be `00` from that response). Thus, if the device is currently on, scale w1, w2, and rgb accordingly. If the device is currently off, scale the last known values - this lets it turn on to the correct scale on all channels that were _previously_ on.