### PR TITLE
Unlock config prior to updating settings

### DIFF
--- a/devicetypes/erocm123/aeon-multisensor-6-advanced.src/aeon-multisensor-6-advanced.groovy
+++ b/devicetypes/erocm123/aeon-multisensor-6-advanced.src/aeon-multisensor-6-advanced.groovy
@@ -556,17 +556,23 @@ def update_needed_settings()
     def configuration = parseXml(configuration_model())
     def isUpdateNeeded = "NO"
     
-    if(!state.needfwUpdate || state.needfwUpdate == ""){
+    if(!state.needfwUpdate || state.needfwUpdate == "") {
        logging("Requesting device firmware version")
        cmds << zwave.versionV1.versionGet()
-    }    
+    }
+
+    if (state.currentProperties."252" != [0]) {
+        logging("Unlocking configuration.")
+        cmds << zwave.configurationV1.configurationSet(configurationValue: integer2Cmd(0, 1), parameterNumber: 252, size: 1)
+        cmds << zwave.configurationV1.configurationGet(parameterNumber: 252)
+    }
 
     if(state.wakeInterval == null || state.wakeInterval != getAdjustedWake()){
         logging("Setting Wake Interval to ${getAdjustedWake()}")
         cmds << zwave.wakeUpV1.wakeUpIntervalSet(seconds: getAdjustedWake(), nodeid:zwaveHubNodeId)
         cmds << zwave.wakeUpV1.wakeUpIntervalGet()
     }
-   
+
     configuration.Value.each
     {     
         if ("${it.@setting_type}" == "zwave"){

--- a/devicetypes/erocm123/aeon-multisensor-6-advanced.src/aeon-multisensor-6-advanced.groovy
+++ b/devicetypes/erocm123/aeon-multisensor-6-advanced.src/aeon-multisensor-6-advanced.groovy
@@ -561,7 +561,7 @@ def update_needed_settings()
        cmds << zwave.versionV1.versionGet()
     }
 
-    if (state.currentProperties."252" != [0]) {
+    if (state.currentProperties?."252" != [0]) {
         logging("Unlocking configuration.")
         cmds << zwave.configurationV1.configurationSet(configurationValue: integer2Cmd(0, 1), parameterNumber: 252, size: 1)
         cmds << zwave.configurationV1.configurationGet(parameterNumber: 252)


### PR DESCRIPTION
My variant of the Multisensor (made by Oomi) shipped with a locked
configuration. This commit should address the issue by checking and
disabling this lock when updates happen.